### PR TITLE
Fix "one hash required" exception

### DIFF
--- a/lib/codesake/commons/logging.rb
+++ b/lib/codesake/commons/logging.rb
@@ -19,35 +19,35 @@ module Codesake
       end
 
       def die(msg, pid_file=nil)
-        STDERR.printf "#{Time.now.strftime("%H:%M:%S")} [!] #{msg}\n".color(:red)
+        STDERR.print "#{Time.now.strftime("%H:%M:%S")} [!] #{msg}\n".color(:red)
         send_to_syslog(msg, :helo)
         Codesake::Commons::Io.remove_pid_file(pid_file) unless pid_file.nil?
         Kernel.exit(-1)
       end
 
       def err(msg)
-        STDERR.printf "#{Time.now.strftime("%H:%M:%S")} [!] #{msg}\n".color(:red)
+        STDERR.print "#{Time.now.strftime("%H:%M:%S")} [!] #{msg}\n".color(:red)
         send_to_syslog(msg, :err)
       end
 
       def warn(msg)
-        STDOUT.printf "#{Time.now.strftime("%H:%M:%S")} [!] #{msg}\n".color(:yellow)
+        STDOUT.print "#{Time.now.strftime("%H:%M:%S")} [!] #{msg}\n".color(:yellow)
         send_to_syslog(msg, :warn)
       end
 
       def ok(msg)
-        STDOUT.printf "#{Time.now.strftime("%H:%M:%S")} [*] #{msg}\n".color(:green)
+        STDOUT.print "#{Time.now.strftime("%H:%M:%S")} [*] #{msg}\n".color(:green)
         send_to_syslog(msg, :log)
       end
 
       def log(msg)
         return if @silencer
-        STDOUT.printf "#{Time.now.strftime("%H:%M:%S")}: #{msg}\n".color(:white)
+        STDOUT.print "#{Time.now.strftime("%H:%M:%S")}: #{msg}\n".color(:white)
         send_to_syslog(msg, :debug)
       end
 
       def helo(msg, pid_file = nil)
-        STDOUT.printf "[*] #{msg} at #{Time.now.strftime("%H:%M:%S")}\n".color(:white)
+        STDOUT.print "[*] #{msg} at #{Time.now.strftime("%H:%M:%S")}\n".color(:white)
         send_to_syslog(msg, :helo)
         Codesake::Commons::Io.create_pid_file(pid_file) unless pid_file.nil?
       end


### PR DESCRIPTION
This can happen when the string which is passed to printf as a first
argument contains a pattern like %{...} and ruby wants to interpolate
it with the keys/values of a seond hash argument to printf. print is
the better method anyway, if no formatting should be performed.
