### PR TITLE
Fix undefined method `color` on `dawn` executing

### DIFF
--- a/lib/codesake/commons/logging.rb
+++ b/lib/codesake/commons/logging.rb
@@ -1,4 +1,4 @@
-require 'rainbow'
+require 'rainbow/ext/string'
 require 'syslog'
 require 'singleton'
 


### PR DESCRIPTION
```
% dawn -k                                                                                                                                                                   

/Users/pftg/.rvm/gems/ruby-2.0.0-p247@agent-bright/gems/codesake-commons-0.90.0/lib/codesake/commons/logging.rb:60:in `helo': undefined method `color' for "22:27:50 [*] dawn v1.0.0 is starting up\n":String (NoMethodError)
```
